### PR TITLE
fix(build): link libc

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,7 @@ pub fn build(b: *std.Build) !void {
         .root_source_file = b.path("src/lib.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
 
     ul.addRPath(.{ .cwd_relative = sdk_bin });


### PR DESCRIPTION
Fixes the following segfault:
```
$ zig build run -DSDK=SDK
Segmentation fault at address 0x0
???:?:?: 0x0 in ??? (???)
run
└─ run example failure
error: the following command terminated unexpectedly:
zig-ultralight/.zig-cache/o/ec4268b3143742b9287fd5287ae3b849/example 
Build Summary: 1/3 steps succeeded; 1 failed (disable with --summary none)
run transitive failure
└─ run example failure
error: the following build command failed with exit code 1:
zig-ultralight/.zig-cache/o/7f1522c36bababd4f4a2668e2b420689/build zig zig-ultralight zig-ultralight/.zig-cache .cache/zig --seed 0x95b10290 -Zef882e41c9b78312 run -DSDK=SDK
```